### PR TITLE
changed title attribute in output files to include "V4."

### DIFF
--- a/src/final_analysis_module.F90
+++ b/src/final_analysis_module.F90
@@ -130,7 +130,7 @@ oa_type , oa_3D_type , oa_3D_option , rad_influence , oa_psfc )
           IF ( itype == 2 ) THEN        ! characters
             rcode = nf_get_att_text (met_ncid, NF_GLOBAL, cname, cval)
             IF(cname(1:5) .eq. 'TITLE') then
-               cval = "OUTPUT FROM OBSGRID"
+               cval = "OUTPUT FROM OBSGRID V4"
                ilen = len_trim(cval)
             ENDIF 
             rcode = nf_put_att_text(oa_ncid, NF_GLOBAL, cname, ilen, cval(1:ilen))


### PR DESCRIPTION
Previously, output files were given the title attribute "OUTPUT FROM OBSGRID," but did not include an explicit version number. Because V4+ of the WRF model doesn't allow for older versions of input (unless using a namelist specification that the data are older), it was necessary to change the code to name the files "OUTPUT FROM OBSGRID V4." 

Neither the structure of the the WPS (metgrid, specifically) output nor the meaning of any of the fields from metgrid were modified in the move from version 3 to version 4. 

   * Having the current obsgrid code always mentioning V4, regardless of the WPS input version, is OK for the real program. 
   * Since the v3 real and WRF codes never checked a version number for consistency, the new obsgrid could supply data to an old v3 real code.

This issue was referenced in and fixes wrf-model/WRF#600
